### PR TITLE
Delete redundant service accounts

### DIFF
--- a/chart/sdk-service/templates/flower/flower-deployment.yaml
+++ b/chart/sdk-service/templates/flower/flower-deployment.yaml
@@ -18,7 +18,6 @@ spec:
       securityContext:
         {{- toYaml .Values.containerSecurityContext | nindent 8 }}
       {{- end }}
-      serviceAccountName: "{{ .Values.serviceAccount }}"
       containers:
         - name: flower
           image: "{{ .Values.flower.image.repository }}:{{ .Values.flower.image.tag }}"

--- a/chart/sdk-service/templates/worker/worker-deployment.yaml
+++ b/chart/sdk-service/templates/worker/worker-deployment.yaml
@@ -18,7 +18,6 @@ spec:
       securityContext:
         {{- toYaml .Values.containerSecurityContext | nindent 8 }}
       {{- end }}
-      serviceAccountName: "{{ .Values.serviceAccount }}"
       containers:
         - name: worker
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"

--- a/chart/sdk-service/values.yaml
+++ b/chart/sdk-service/values.yaml
@@ -73,9 +73,6 @@ worker:
   # If secretRef is used, the envRenderSecret parameter will be omitted (in case that it has content).
   secretRef:
 
-
-serviceAccount:
-
 securityContext: {}
   # capabilities:
   #   drop:

--- a/docs/k8s-cli-installation.md
+++ b/docs/k8s-cli-installation.md
@@ -119,15 +119,6 @@ kubectl create namespace "${NAMESPACE}"
 
 ### Creating the Service Account
 
-To create the Service Account and ClusterRoleBinding:
-
-```shell
-export SDK_SERVICE_ACCOUNT="${APP_INSTANCE_NAME}-serviceaccount"
-kubectl create serviceaccount "${SDK_SERVICE_ACCOUNT}" --namespace "${NAMESPACE}"
-kubectl create clusterrole "${SDK_SERVICE_ACCOUNT}-role" --verb=get,list,watch --resource=services,nodes,pods,namespaces
-kubectl create clusterrolebinding "${SDK_SERVICE_ACCOUNT}-rule" --clusterrole="${SDK_SERVICE_ACCOUNT}-role" --serviceaccount="${NAMESPACE}:${SDK_SERVICE_ACCOUNT}"
-```
-
 Set or generate the password for Redis:
 
 ```shell
@@ -160,7 +151,6 @@ expanded manifest file for future updates to your app.
 helm template chart/sdk-service \
   --name-template "${APP_INSTANCE_NAME}" \
   --namespace "${NAMESPACE}" \
-  --set serviceAccount="${SDK_SERVICE_ACCOUNT}" \
   --set flower.image.repository="${IMAGE_FLOWER}" \
   --set flower.image.tag="${TAG}" \
   --set redis.image.repository="${IMAGE_REDIS}" \

--- a/docs/k8s-cli-installation.md
+++ b/docs/k8s-cli-installation.md
@@ -117,8 +117,6 @@ running the following command:
 kubectl create namespace "${NAMESPACE}"
 ```
 
-### Creating the Service Account
-
 Set or generate the password for Redis:
 
 ```shell

--- a/schema.yaml
+++ b/schema.yaml
@@ -85,29 +85,6 @@ properties:
         type: SSD
 
   # Generated values
-  serviceAccount:
-    type: string
-    title: Service account used by all instances
-    x-google-marketplace:
-      type: SERVICE_ACCOUNT
-      serviceAccount:
-        description: Service account used by Synthesized SDK deployment
-        roles:
-          - type: ClusterRole
-            rulesType: CUSTOM
-            rules:
-              - apiGroups: [ "" ]
-                resources: [ "pods", "serviceaccounts" ]
-                verbs: [ "get", "list" ]
-              - apiGroups: [ "extensions" ]
-                resources: [ "deployments" ]
-                verbs: [ "get", "list" ]
-              - apiGroups: [ "apps" ]
-                resources: [ "deployments" ]
-                verbs: [ "get", "list" ]
-              - apiGroups: [ "" ]
-                resources: [ "pods/exec" ]
-                verbs: [ "create", "get" ]
   redis.password:
     type: string
     x-google-marketplace:


### PR DESCRIPTION
The service accounts had unnecessary permissions and weren't needed for the service, so they were deleted.